### PR TITLE
Fix backspace handling on SFML OpenGL 2 demo

### DIFF
--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -336,8 +336,11 @@ nk_sfml_handle_event(sf::Event* evt)
         } else nk_input_motion(ctx, evt->touch.x, evt->touch.y);
         return 1;
     } else if(evt->type == sf::Event::TextEntered) {
-        nk_input_unicode(ctx, evt->text.unicode);
-        return 1;
+	    if (evt->text.unicode != 8) {
+		// don't pass backspace (ascii code 8)
+        	nk_input_unicode(ctx, evt->text.unicode);
+        	return 1;
+	    }
     } else if(evt->type == sf::Event::MouseWheelScrolled) {
         nk_input_scroll(ctx, nk_vec2(0,evt->mouseWheelScroll.delta));
         return 1;

--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -339,8 +339,8 @@ nk_sfml_handle_event(sf::Event* evt)
 	    if (evt->text.unicode != 8) {
 		// don't pass backspace (ascii code 8)
         	nk_input_unicode(ctx, evt->text.unicode);
-        	return 1;
 	    }
+	    return 1;
     } else if(evt->type == sf::Event::MouseWheelScrolled) {
         nk_input_scroll(ctx, nk_vec2(0,evt->mouseWheelScroll.delta));
         return 1;


### PR DESCRIPTION
Previously, backspace characters would be passed directly to nk_input_unicode, resulting in backspace not working and instead simply inserting ASCII backspace '\b' into the text.
This fixes it by filtering out '\b' in the event handler.